### PR TITLE
handle no results from tvdb-series-search

### DIFF
--- a/src/components/SeriesSearch.vue
+++ b/src/components/SeriesSearch.vue
@@ -71,7 +71,13 @@ export default {
                 body: JSON.stringify({token: {token: this.token}, query: {name: this.query}})
             })
             .then(response => response.json())
-            .then(results => this.results = results.results)
+            .then(results => {
+                if (Object.entries(results.results).length === 0) {
+                    this.results = `No results found for: "${this.query}"`
+                } else {
+                    this.results = results.results
+                }
+            })
         },
         hover: function(item, v) {
             item.hovered = v;


### PR DESCRIPTION
When a query has no results from TVDB, the serverless function will return:

```
{}
```

In this case, the frontend will now display the message:

```
No results found for: "query"
```